### PR TITLE
Update mkclipw.sh

### DIFF
--- a/mkclipw.sh
+++ b/mkclipw.sh
@@ -19,5 +19,5 @@ curl -X POST https://portal.muuktest.com:8081/download_byproperty -H @header.txt
 [ -d "./test" ] && rm -r test
 unzip test.zip -d ./test
 echo "Executing tests on Playwright"
-npx playwright test --workers=4
+npx playwright test --workers=4 --project=chromium
 echo "Execution Completed."


### PR DESCRIPTION
The current mkclipw.sh is missing the full command for the project parameter, which is triggering two executions one failed one passed. 

